### PR TITLE
envsetup: Use GNU sed commands if GNU sed is detected

### DIFF
--- a/build/envsetup.sh
+++ b/build/envsetup.sh
@@ -816,8 +816,10 @@ function dopush()
         rm -f $OUT/.log;return $ret
     fi
 
+    is_gnu_sed=`sed --version | head -1 | grep -c GNU`
+
     # Install: <file>
-    if [ `uname` = "Linux" ]; then
+    if [ $is_gnu_sed -gt 0 ]; then
         LOC="$(cat $OUT/.log | sed -r -e 's/\x1B\[([0-9]{1,2}(;[0-9]{1,2})?)?[m|K]//g' -e 's/^\[ {0,2}[0-9]{1,3}% [0-9]{1,6}\/[0-9]{1,6}\] +//' \
             | grep '^Install: ' | cut -d ':' -f 2)"
     else
@@ -826,7 +828,7 @@ function dopush()
     fi
 
     # Copy: <file>
-    if [ `uname` = "Linux" ]; then
+    if [ $is_gnu_sed -gt 0 ]; then
         LOC="$LOC $(cat $OUT/.log | sed -r -e 's/\x1B\[([0-9]{1,2}(;[0-9]{1,2})?)?[m|K]//g' -e 's/^\[ {0,2}[0-9]{1,3}% [0-9]{1,6}\/[0-9]{1,6}\] +//' \
             | grep '^Copy: ' | cut -d ':' -f 2)"
     else


### PR DESCRIPTION
The current check only checks for Linux, but many of us
use GNU sed on darwin as well, which means the non-Linux
command will fail, so read the sed version and use the GNU
command if GNU is found in the version string.

Change-Id: I7eefd0309751b069eef5e5e2b907d3d4f38f1638