### PR TITLE
qcom: Permit dumpstate to run "ip xfrm policy"

### DIFF
--- a/sepolicy/qcom/dumpstate.te
+++ b/sepolicy/qcom/dumpstate.te
@@ -8,3 +8,4 @@ allow dumpstate fuse:file r_file_perms;
 allow dumpstate themeservice_app_data_file:dir r_dir_perms;
 allow dumpstate themeservice_app_data_file:file r_file_perms;
 allow dumpstate media_rw_data_file:dir search;
+allow dumpstate wcnss_service_exec:file rx_file_perms;


### PR DESCRIPTION
* dumpstate needs execute permissions for wcnss_service

Change-Id: Ic2b39c877c28b330f6631f44277830d274878fbb