### PR TITLE
kernel: Fix broken C_INCLUDE_PATH for Darwin

### DIFF
--- a/build/tasks/kernel.mk
+++ b/build/tasks/kernel.mk
@@ -261,8 +261,7 @@ define clean-module-folder
 endef
 
 ifeq ($(HOST_OS),darwin)
-  MAKE_FLAGS += C_INCLUDE_PATH=$(ANDROID_BUILD_TOP)/external/elfutils/libelf/
-  MAKE_FLAGS += C_INCLUDE_PATH=/usr/local/opt/openssl/include
+  MAKE_FLAGS += C_INCLUDE_PATH=$(ANDROID_BUILD_TOP)/external/elfutils/libelf:/usr/local/opt/openssl/include
   MAKE_FLAGS += LIBRARY_PATH=/usr/local/opt/openssl/lib
 endif
 


### PR DESCRIPTION
Commit 7fb9251dfcc7a0876c8fb906338452204942144a modified
the expansion in an illegal way.

Fix the broken env variable.

Change-Id: Ib3029fa995d6a4b0416887a2ef2e4792c9e6bb27