### PR TITLE
qcom: Allow setting custom audio, display, and media HALs

### DIFF
--- a/build/core/qcom_target.mk
+++ b/build/core/qcom_target.mk
@@ -101,9 +101,9 @@ ifeq ($(BOARD_USES_QCOM_HARDWARE),true)
     endif
     endif
 
-$(call project-set-path,qcom-audio,hardware/qcom/audio-caf/$(QCOM_HARDWARE_VARIANT))
-$(call project-set-path,qcom-display,hardware/qcom/display-caf/$(QCOM_HARDWARE_VARIANT))
-$(call project-set-path,qcom-media,hardware/qcom/media-caf/$(QCOM_HARDWARE_VARIANT))
+$(call set-device-specific-path,AUDIO,audio,hardware/qcom/audio-caf/$(QCOM_HARDWARE_VARIANT))
+$(call set-device-specific-path,DISPLAY,display,hardware/qcom/display-caf/$(QCOM_HARDWARE_VARIANT))
+$(call set-device-specific-path,MEDIA,media,hardware/qcom/media-caf/$(QCOM_HARDWARE_VARIANT))
 
 $(call set-device-specific-path,CAMERA,camera,hardware/qcom/camera)
 $(call set-device-specific-path,GPS,gps,hardware/qcom/gps)


### PR DESCRIPTION
Currently, using project-set-path is blocking us from overriding the pathmap
for the audio, display, and media HALs, so set them with set-device-specific-path
to allow overriding the HALs with USE_DEVICE_SPECIFIC_* and DEVICE_SPECIFIC_*_PATH

Change-Id: Iee3723cf251d0f485a77a17fd61cb62178833582