### PR TITLE
extract_utils: Allow to interrupt the extraction

### DIFF
--- a/build/tools/extract_utils.sh
+++ b/build/tools/extract_utils.sh
@@ -37,7 +37,7 @@ function cleanup() {
     rm -rf "${TMPDIR:?}"
 }
 
-trap cleanup EXIT INT TERM ERR
+trap cleanup 0
 
 #
 # setup_vendor


### PR DESCRIPTION
We want to cleanup our temporary files independently on the signal,
so just execute a trap on 0. This will ensure temporary files are
always removed and doesn't require any extra care when trapping
signals such as SIGINT that require an explicit exit call.

Change-Id: Ieff4f15c44a9ac9d5a543d14c140ebd72c0e7344