### PR TITLE
extract_utils: Use temporary folder for system dump

### DIFF
--- a/build/tools/extract_utils.sh
+++ b/build/tools/extract_utils.sh
@@ -827,7 +827,7 @@ function extract() {
     fi
 
     if [ -f "$SRC" ] && [ "${SRC##*.}" == "zip" ]; then
-        DUMPDIR="$CM_ROOT"/system_dump
+        DUMPDIR="$TMPDIR"/system_dump
 
         # Check if we're working with the same zip that was passed last time.
         # If so, let's just use what's already extracted.


### PR DESCRIPTION
 * This way it's automatically deleted at the end of the extraction

Change-Id: I77b3357875b8070d370f04c5a245f9aa3ca1939c